### PR TITLE
hotfix: 빈배열로 왔을 때 구독리스트 최근 본 아티클 가이드 텍스트 보여주기 

### DIFF
--- a/apps/service/features/recent-newsletter/api/fetchNewsletterList.ts
+++ b/apps/service/features/recent-newsletter/api/fetchNewsletterList.ts
@@ -8,8 +8,8 @@ const fetchNewsletterList = async (
     { cache: 'no-store' },
   ).then((res) => res.json())
 
-  const { myPageArticles } = data
-  return myPageArticles
+  const { mypageArticles } = data
+  return mypageArticles
 }
 
 export default fetchNewsletterList

--- a/apps/service/features/recent-newsletter/ui/RecentNewsletterContainer.tsx
+++ b/apps/service/features/recent-newsletter/ui/RecentNewsletterContainer.tsx
@@ -11,10 +11,10 @@ export default function RecentNewsletterContainer({
   recentNewLetterList,
 }: RecentNewsletterProps) {
   return (
-    <Background className="h-full">
+    <Background className="h-full overflow-hidden">
       <div className="flex items-center justify-between p-5">
         <p className="cursor-default text-lg font-bold">최근 읽은 아티클</p>
-        {recentNewLetterList ? (
+        {recentNewLetterList.length !== 0 ? (
           <Link
             href="/inbox"
             className="text-sm font-medium text-gray-500 hover:text-blue-400 dark:hover:text-blue-300">
@@ -24,13 +24,13 @@ export default function RecentNewsletterContainer({
           ''
         )}
       </div>
-      {recentNewLetterList ? (
+      {recentNewLetterList.length !== 0 ? (
         <div className="relative w-full">
           <div
             className=" overflow-x-auto
         before:absolute before:inset-y-0 before:left-0 before:z-10 before:w-5 before:bg-gradient-to-r before:from-white before:to-transparent after:absolute after:inset-y-0 after:right-0 after:z-10 after:w-5 after:bg-gradient-to-l after:from-white after:to-transparent dark:before:from-gray-800 dark:after:from-gray-800
         ">
-            <div className="flex min-w-fit items-start justify-start gap-4 px-8 py-2">
+            <div className="flex min-w-fit items-start justify-start gap-4 px-8 py-4">
               {recentNewLetterList.map((newsItem) => (
                 <Link href={`inbox/article/${newsItem.id}`} key={newsItem.id}>
                   <NewsCard key={newsItem.id}>

--- a/apps/service/features/subscribe-list/ui/SubscribeList.tsx
+++ b/apps/service/features/subscribe-list/ui/SubscribeList.tsx
@@ -19,7 +19,7 @@ export default function SubscribeList({ subscribeList }: SubscribeListProps) {
       <div className="h-full px-4 py-5">
         <p className="mb-4 text-lg font-bold">구독 리스트</p>
         {subscribeList.length !== 0 ? (
-          <ul className="flex h-60 flex-col justify-start overflow-y-auto lg:h-[calc(100%-64px)]">
+          <ul className="flex flex-col justify-start overflow-y-auto lg:h-[calc(100%-64px)]">
             {subscribeList.map((item) => (
               <Link
                 href={`newsletter/${item.id}`}


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- (최근본 아티클 및 구독리스트 빈배열로 왔을 때 가이드 텍스트 보여주기)[https://attractorr.atlassian.net/browse/ATR-249]

<br/>

## 🔑 Key Changes

- 최근본 아티클 및 구독리스트 빈배열로 왔을 때 가이드 텍스트 보여주기